### PR TITLE
0000 | adds handling for no null denomination and null quantity in ad…

### DIFF
--- a/src/resources/scripts/page.js
+++ b/src/resources/scripts/page.js
@@ -63,7 +63,7 @@ const App = () => {
 	};
 
 	const addMoney = (denomination, count) => {
-		if(count <= 0){return false}
+		if(count <= 0 || denomination === 0){return false}
 		setRegister(prevRegister => ({
 			...prevRegister,
 			[denomination]: prevRegister[denomination] + count
@@ -71,7 +71,7 @@ const App = () => {
 	};
 
 	const removeMoney = (denomination, count) => {
-		if(count <= 0){return false}
+		if(count <= 0 || denomination === 0){return false}
 		if (register[denomination] >= count) {
 			setRegister(prevRegister => ({
 				...prevRegister,


### PR DESCRIPTION
There was an error that occured when you added a quantity to deduct or add but did not have a quantity associated. This would make the wallet display inappropriately and break the UI. A user needs to add a quantity and a denomination.