### PR TITLE
0000 | bug fix making change should never reduce the total amount.

### DIFF
--- a/src/resources/scripts/page.js
+++ b/src/resources/scripts/page.js
@@ -76,18 +76,16 @@ const App = () => {
 		const denominations = [20, 10, 5, 2, 1];
 		let remaining = amount;
 		let change = {};
-		let newRegister = { ...register };
 		for (let bill of denominations) {
-			let count = Math.min(Math.floor(remaining / bill), newRegister[bill]);
+			let count = Math.min(Math.floor(remaining / bill), register[bill]);
 			if (count > 0) {
 				change[bill] = count;
 				remaining -= count * bill;
-				newRegister[bill] -= count;
+				register[bill] -= count;
 			}
 		}
 
 		if (remaining === 0) {
-			setRegister(newRegister);
 			setError('');
 			alert(`Change: ${formatChange(change)}`);
 		} else {


### PR DESCRIPTION
Making change should never reduce your total wallet. 

FUTURE FIX:
We should know what denominations and their qty they gave us so we can track that change in our wallet. Right now the user gives us a number and no further context. If we knew they wanted to make change for $60 it would be helpful to know how to best return the change to the user. This would change our wallet based off what was given to us. Now we just take $60, no context, and return the same amount to the user. Sort of like they gave us $60 bucks in any fashion and we will return something they want but not how they need it.